### PR TITLE
MNT Use yarn install

### DIFF
--- a/.github/workflows/update-js-deps.yml
+++ b/.github/workflows/update-js-deps.yml
@@ -38,8 +38,13 @@ jobs:
           git checkout 1
           yarn install
           cd $DIR
-      - name: Yarn upgrade
-        run: yarn upgrade
+
+      # Use `yarn install` rather than `yarn upgrade` to prevent the following error:
+      # "error Outdated lockfile. Please run `yarn install` and try again."
+      - name: Update yarn.lock
+        run: |
+          if [ -f yarn.lock ]; then rm yarn.lock; fi
+          yarn install
 
       - name: Read package.json
         id: package-json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 By default will run Silverstripe Unit tests and PHPCS code linting.
 
-It's highly recommended that you use a tagged version (e.g. 0.1.2) to ensure stability of your builds. If you have a relatively simple build that you have no intention of ever making more complex e.g. only phpunit tests using phpunit.xml.dist, then this is probably all you need for long term use.
+It's highly recommended that you use a tagged version (e.g. 0.1.16) to ensure stability of your builds. If you have a relatively simple build that you have no intention of ever making more complex e.g. only phpunit tests using phpunit.xml.dist, then this is probably all you need for long term use.
 
 This repository is currently in development and code on the `main` branch could change at any time, including taking on a whole new direction. It's expected that new functionality will be added.
 
@@ -22,7 +22,7 @@ on:
 
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.15
+    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.16
 ```
 
 Use the following if your module does not have a `phpcs.xml.dist` file
@@ -33,7 +33,7 @@ Use the following if your module does not have a `phpcs.xml.dist` file
 ```
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.15
+    uses: silverstripe/github-actions-ci-cd/.github/workflows/ci.yml@0.1.16
     with:
       run_phplinting: false
 ```
@@ -69,5 +69,5 @@ on:
   workflow_dispatch:
 jobs:
   ci:
-    uses: silverstripe/github-actions-ci-cd/.github/workflows/update-js-deps.yml@0.1.15
+    uses: silverstripe/github-actions-ci-cd/.github/workflows/update-js-deps.yml@0.1.16
 ```


### PR DESCRIPTION
Use `yarn install` instead of `yarn upgrade` to prevent this error https://github.com/silverstripe/silverstripe-campaign-admin/runs/5489724194?check_suite_focus=true#step:7:8

Tag 0.1.16 when merged