### PR TITLE
NEW Create auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,44 @@
+# Non-shared workflow that only runs on the github-actions-ci-cd module to automatically
+# delete and re-release tags so that other modules can use something similar to carets (^)
+# Caret (^) requirements are not supported by github-action e.g. @^2 does not work
+# The action will tag v2 when 2.5.0 is released and v0.3 when 0.3.5 is released
+# The new 'v' tag will point to the same sha  e.g. the sha of v2 will equal the sha of 2.5.0
+# This allows modules to include workflows using the @v2 or @v0.3 syntax
+# Using the 'v' prefix to avoid confusion with the '2' branch naming convention that Silverstripe uses
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  auto-tag:
+    name: Auto-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate tag name
+        id: generate_tag_name
+        run: |
+          # refs/tags/0.1.23 => 0.1.23
+          TAG=$(echo ${{ github.ref }} | cut -c 11-)
+          if [[ $TAG =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            NEW_TAG="v${MAJOR}"
+            if [ "$MAJOR" == "0" ]; then
+              NEW_TAG=("v${MAJOR}.${MINOR}")
+            fi
+            echo "Tag is $NEW_TAG"
+            echo "::set-output name=tag::$NEW_TAG"
+          else
+            echo "Tag does not match 1.2.3 format, exiting"
+            exit 1
+          fi
+      - name: Add tag to repo
+        uses: emteknetnz/gha-tag-release@main
+        with:
+          sha: ${{ github.sha }}
+          tag: ${{ steps.generate_tag_name.outputs.tag }}
+          delete_existing: true
+          release: false


### PR DESCRIPTION
Issue - https://github.com/silverstripeltd/product-issues/issues/367

carets (^) do not work in github actions for getting the latest semantic version of an action e.g. @^2 doesn't work

Instead, what needs to be done is to tag a new 'major' version each time, so that it can instead be required as @v2

This is consistent with what github actions/checkout does - https://github.com/actions/checkout/tags

This workflow automatically recreates a new major version tag each time a semantic version of this module is tagged

I haven't bothered to create a new minor version as well, as I think it's more then what's actually required in the real-world

Here's an example of why we need this workflow - https://github.com/silverstripe/silverstripe-campaign-admin/actions/runs/1965267629 - the issue this run had was patched in 0.1.16 of silverstripe/github-action-ci-cd, however the module only requires ci.yml@^0.1.15.  After merging this pull-reqest, we can update campaign-admin (and other js modules) to instead require ci.yml@v0.1

Example of this workflow running on a made up tag 3.2.2:
https://github.com/emteknetnz/github-actions-ci-cd/actions/runs/1996324988
[v3 tag](https://github.com/emteknetnz/github-actions-ci-cd/releases/tag/v3)

Example of this workflow failing when it's supposed to on a 3.2.3-beta1 tag:
https://github.com/emteknetnz/github-actions-ci-cd/actions/runs/1996326747